### PR TITLE
Dev build change

### DIFF
--- a/.github/workflows/dev_build.yml
+++ b/.github/workflows/dev_build.yml
@@ -1,8 +1,5 @@
 name: Dev Build
 on:
-    push:
-        branches:
-            - development
     pull_request:
         types: [opened, synchronize, reopened]
         branches:


### PR DESCRIPTION
# Description

This resolves the issue brought up in #7 to remove builds running on pushes to the development branch. This should now only happen when pulls go to development.